### PR TITLE
Implement axis sorting

### DIFF
--- a/python/ndtiff/ndtiff_v1.py
+++ b/python/ndtiff/ndtiff_v1.py
@@ -11,6 +11,12 @@ import dask.array as da
 import warnings
 import struct
 
+_POSITION_AXIS = "position"
+_ROW_AXIS = "row"
+_COLUMN_AXIS = "column"
+_Z_AXIS = "z"
+_TIME_AXIS = "time"
+_CHANNEL_AXIS = "channel"
 
 class _MultipageTiffReader:
     # Class corresponsing to a single multipage tiff file in a Micro-Magellan dataset. Pass the full path of the TIFF to
@@ -393,11 +399,6 @@ class _ResolutionLevel:
 class NDTiff_v1():
     """Class that opens a single NDTiffStorage dataset (major versions 0 and 1)"""
 
-    _POSITION_AXIS = "position"
-    _Z_AXIS = "z"
-    _TIME_AXIS = "time"
-    _CHANNEL_AXIS = "channel"
-
     def __init__(self, dataset_path=None, full_res_only=True, remote_storage=None):
         self._tile_width = None
         self._tile_height = None
@@ -469,10 +470,10 @@ class NDTiff_v1():
                 # the c here refers to super channels, encompassing all non-tzp axes in addition to channels
                 # map of axis names to values where data exists
                 self.axes = {
-                    self._Z_AXIS: set(),
-                    self._TIME_AXIS: set(),
                     self._POSITION_AXIS: set(),
+                    self._TIME_AXIS: set(),
                     self._CHANNEL_AXIS: set(),
+                    self._Z_AXIS: set(),
                 }
 
                 # Need to map "super channels", which absorb all non channel/z/time/position axes to channel indices
@@ -543,7 +544,7 @@ class NDTiff_v1():
                                 self.axes[self._TIME_AXIS].add(t)
                                 for p in c_z_t_p_tree[c][z][t]:
                                     self.axes[self._POSITION_AXIS].add(p)
-                                    if c not in self.axes["channel"]:
+                                    if c not in self.axes[self._CHANNEL_AXIS]:
                                         metadata = self.res_levels[0].read_metadata(
                                             channel_index=c, z_index=z, t_index=t, pos_index=p
                                         )

--- a/python/ndtiff/test/data_loading_test.py
+++ b/python/ndtiff/test/data_loading_test.py
@@ -5,17 +5,17 @@ import os
 test_data_path = os.getcwd() + os.sep + 'test_data' + os.sep
 
 def test_v2_data():
-    data_path = test_data_path + "v2/ndtiffv2.0_test"
+    data_path = os.path.join(test_data_path, "v2", "ndtiffv2.0_test")
     dataset = Dataset(data_path)
     assert(np.mean(dataset.as_array()) > 0)
 
 def test_v3_data():
-    data_path = test_data_path + 'v3/ndtiffv3.0_test'
+    data_path = os.path.join(test_data_path, 'v3', 'ndtiffv3.0_test')
     dataset = Dataset(data_path)
     assert(np.mean(dataset.as_array()) > 0)
 
 def test_v2_stitched_data():
-    data_path = test_data_path + "v2/ndtiffv2.0_stitched_test"
+    data_path = os.path.join(test_data_path, "v2", "ndtiffv2.0_stitched_test")
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array(stitched=True))
     assert(stitched[..., 0, 0] > 0)
@@ -24,7 +24,7 @@ def test_v2_stitched_data():
     assert(stitched[..., -1, 0] == 0)
 
 def test_v3_stitched_data():
-    data_path = test_data_path + 'v3/ndtiffv3.0_stitched_test'
+    data_path = os.path.join(test_data_path, 'v3', 'ndtiffv3.0_stitched_test')
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array(stitched=True, res_level=0))
     assert(stitched[..., 0, 0] > 0)
@@ -33,22 +33,22 @@ def test_v3_stitched_data():
     assert(stitched[..., -1, 0] == 0)
 
 def test_v3_magellan_explore():
-    data_path = test_data_path + 'v3/Magellan_expolore_multi_channel'
+    data_path = os.path.join(test_data_path, 'v3', 'Magellan_expolore_multi_channel')
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array(stitched=True, res_level=0))
     
 def test_v3_magellan_explore_negative_and_overwritten():
-    data_path = test_data_path + 'v3/Magellan_expolore_negative_indices_and_overwritten'
+    data_path = os.path.join(test_data_path, 'v3', 'Magellan_expolore_negative_indices_and_overwritten')
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array(stitched=True, res_level=0))
 
 def test_v3_non_ctzp_axes():
-    data_path = test_data_path + 'v3/Nonstandard_axis_names'
+    data_path = os.path.join(test_data_path, 'v3', 'Nonstandard_axis_names')
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array())
 
 def test_v3_mm_mda():
-    data_path = test_data_path + 'v3/mm_mda_tcz_15'
+    data_path = os.path.join(test_data_path, 'v3', 'mm_mda_tcz_15')
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array())
 


### PR DESCRIPTION
This PR implements sorting of the dataset axes in `PTCZYX` order.

In the original implementation of `Dataset.as_array()`, data is returned in random/unknown dimension order if the `axes=None` argument is not explicitly set. This presents some overhead.

In this PR the array axes are sorted at initialization such that `Dataset.as_array(axes=None)` returns an array in predictable `PTCZYX` order.

Rows and columns are arranged in front, i.e. `RowColCZYX`, and extra axes are placed next to channel, i.e. PTABCZYX if `axes=None`; however, in these cases it is best to specify the axis order explicitly.

@henrypinkard should this order be applied to new axes in `_add_index_entry` as well? How about extending this to the v1 and v2 `ndtiff` file readers?