### PR TITLE
Bugfix read empty datasets

### DIFF
--- a/python/ndtiff/_version.py
+++ b/python/ndtiff/_version.py
@@ -1,2 +1,2 @@
-version_info = (1, 8, 1)
+version_info = (1, 8, 2)
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
This PR initializes ndtiff class properties as empty to prevent errors in reading dataset which contain no images (see `test_empty_mda_acq`)