### PR TITLE
Update maven deployment workflow to execute on micro-manager/NDTiffStorage only

### DIFF
--- a/.github/workflows/maven_deployment_and_pm_update.yml
+++ b/.github/workflows/maven_deployment_and_pm_update.yml
@@ -15,6 +15,7 @@ jobs:
   maven-deploy:
     name: Release on Sonatype OSS
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'micro-manager/NDTiffStorage' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ __pycache__/
 target/
 .idea
 
+*.iml
+
 .vscode/*


### PR DESCRIPTION
This update will prevent the maven deployment workflow to execute on repo forks as that fails. If this works well, I can transfer that to the other repos as well