### PR TITLE
Fix AttributeError: 'int' object has no attribute 'close'

### DIFF
--- a/python/ndtiff/nd_tiff_v2.py
+++ b/python/ndtiff/nd_tiff_v2.py
@@ -724,7 +724,7 @@ class NDTiff_v2_0():
 
     def close(self):
         with self._lock:
-            for res_level in self.res_levels:
+            for res_level in self.res_levels.values():
                 res_level.close()
 
     def get_channel_names(self):


### PR DESCRIPTION
Fixes
```python
self = <ndtiff.nd_tiff_v2.NDTiff_v2_0 object at 0x0000017E77D3A490>

    def close(self):
        with self._lock:
            for res_level in self.res_levels:
>               res_level.close()
E               AttributeError: 'int' object has no attribute 'close'

X:\Python311\Lib\site-packages\ndtiff\nd_tiff_v2.py:728: AttributeError
```