### PR TITLE
Removed mmap interface, added file_io supporting arbitrary IO functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,20 @@ A listing of all the images contained in the file and their byte offsets. This a
 ### Image display settings
 
 Image display settings (channel contrast and colors). The first 4 bytes of this block contain the Display Settings Header (347834724 = 0x14BB8964), and the next 4 contain the number of subsequent bytes reserved for display settings. A UTF-8 JSON string containing display settings is written.
+
+
+## Support for Cloud-based IO
+The python `ndtiff` package supports IO to cloud services (i.e. AWS s3) via thr `file_io` submodule.
+you will need to provide your own file interface methods (or use those from other packages i.e. `boto3`), in the following way:
+```
+from _your_custom_storage_module_ import storage
+import ndtiff
+
+file_io = ndtiff.file_io.NDTiffFileIO(open_function=storage.open,
+                                      listdir_function=storage.listdir,
+                                      path_join_function=storage.pathjoin, 
+                                      isdir_function=storage.isdir)
+
+dset = ndtiff.Dataset("s3://bucket_name/path/to/your/dataset", file_io=file_io)
+```
+

--- a/python/ndtiff/_superclass.py
+++ b/python/ndtiff/_superclass.py
@@ -3,57 +3,57 @@ from ndtiff.nd_tiff_current import NDTiffDataset, NDTiffPyramidDataset
 from ndtiff.nd_tiff_v2 import NDTiff_v2_0
 from ndtiff.ndtiff_v1 import NDTiff_v1
 import numpy as np
-
+from ndtiff.file_io import NDTiffFileIO, BUILTIN_FILE_IO
 
 class Dataset:
     """
     Generic class for opening NDTiff datasets. Creating an instance of this class will
     automatically return an instance of the class appropriate to the version and type of NDTiff dataset required
     """
-    def __new__(cls, dataset_path=None, remote_storage_monitor=None):
+    def __new__(cls, dataset_path=None, remote_storage_monitor=None, file_io: NDTiffFileIO = BUILTIN_FILE_IO):
         ## Datasets currently being collected--must be v3
         if dataset_path is None:
             # Check if its a multi-res pyramid or regular
             if "GridPixelOverlapX" in remote_storage_monitor.get_summary_metadata():
                 obj = NDTiffPyramidDataset.__new__(NDTiffPyramidDataset)
-                obj.__init__(remote_storage_monitor=remote_storage_monitor, dataset_path=dataset_path)
+                obj.__init__(remote_storage_monitor=remote_storage_monitor, file_io=file_io)
             else:
                 obj = NDTiffDataset.__new__(NDTiffDataset)
-                obj.__init__(remote_storage_monitor=remote_storage_monitor, dataset_path=dataset_path)
+                obj.__init__(remote_storage_monitor=remote_storage_monitor, dataset_path=dataset_path, file_io=file_io)
             return obj
 
         # Search for Full resolution dir, check for index
         res_dirs = [
-            dI for dI in os.listdir(dataset_path) if os.path.isdir(os.path.join(dataset_path, dI))
+            dI for dI in file_io.listdir(dataset_path) if file_io.isdir(file_io.path_join(dataset_path, dI))
         ]
         if "Full resolution" not in res_dirs:
             # Full resolution was removed ND Tiff starting in V3 for non-stitched
             fullres_path = dataset_path
             # but if it doesn't have an index, than something is wrong
-            if "NDTiff.index" not in os.listdir(fullres_path):
+            if "NDTiff.index" not in file_io.listdir(fullres_path):
                 raise Exception('Cannot find NDTiff index')
             # It must be an NDTiff >= 3.0 non-multi-resolution, loaded from disk
             obj = NDTiffDataset.__new__(NDTiffDataset)
-            obj.__init__(dataset_path, remote_storage_monitor=remote_storage_monitor)
+            obj.__init__(dataset_path, remote_storage_monitor=remote_storage_monitor, file_io=file_io)
             return obj
         fullres_path = (
                 dataset_path + ("" if dataset_path[-1] == os.sep else os.sep) + "Full resolution" + os.sep)
         # It could still be a multi-res v3. Need to parse a Tiff and check major version
-        a_tiff_file = [file for file in os.listdir(fullres_path) if '.tif' in file][0]
-        file = open(fullres_path + a_tiff_file, "rb")
+        a_tiff_file = [file for file in file_io.listdir(fullres_path) if '.tif' in file][0]
+        file = file_io.open(fullres_path + a_tiff_file, "rb")
         file.seek(12)
         major_version = np.frombuffer(file.read(4), dtype=np.uint32)[0]
         if major_version == 3:
             obj = NDTiffPyramidDataset.__new__(NDTiffPyramidDataset)
-            obj.__init__(dataset_path=dataset_path)
+            obj.__init__(dataset_path=dataset_path, file_io=file_io)
             return obj
 
         # It's a version 2 or a version 1. Check the name of the index file
-        if "NDTiff.index" in os.listdir(fullres_path):
+        if "NDTiff.index" in file_io.listdir(fullres_path):
             obj = NDTiff_v2_0.__new__(NDTiff_v2_0)
-            obj.__init__(dataset_path, full_res_only=True, remote_storage_monitor=remote_storage_monitor)
+            obj.__init__(dataset_path, full_res_only=True, remote_storage_monitor=remote_storage_monitor, file_io=file_io)
             return obj
         else:
             obj = NDTiff_v1.__new__(NDTiff_v1)
-            obj.__init__(dataset_path, full_res_only=True, remote_storage=None)
+            obj.__init__(dataset_path, full_res_only=True, remote_storage=None, file_io=file_io)
             return obj

--- a/python/ndtiff/_version.py
+++ b/python/ndtiff/_version.py
@@ -1,2 +1,2 @@
-version_info = (1, 9, 1)
+version_info = (1, 9, 2)
 __version__ = ".".join(map(str, version_info))

--- a/python/ndtiff/_version.py
+++ b/python/ndtiff/_version.py
@@ -1,2 +1,2 @@
-version_info = (1, 9, 2)
+version_info = (1, 10, 0)
 __version__ = ".".join(map(str, version_info))

--- a/python/ndtiff/file_io.py
+++ b/python/ndtiff/file_io.py
@@ -1,0 +1,28 @@
+import os
+import builtins
+from typing import Callable
+
+# Default open context manager
+BUILTIN_OPEN: Callable = builtins.open
+BUILTIN_LISTDIR: Callable = os.listdir
+BUILTIN_PATH_JOIN: Callable = os.path.join
+BUILTIN_ISDIR: Callable = os.path.isdir
+
+class NDTiffFileIO:
+
+    def __init__(self,
+                 open_function: Callable = BUILTIN_OPEN,
+                 listdir_function: Callable = BUILTIN_LISTDIR,
+                 path_join_function: Callable = BUILTIN_PATH_JOIN, 
+                 isdir_function: Callable = BUILTIN_ISDIR):
+        """Define a group of IO functions for use within this module."""
+        self.open = open_function
+        self.listdir = listdir_function
+        self.path_join = path_join_function
+        self.isdir = isdir_function
+
+# Default values
+BUILTIN_FILE_IO = NDTiffFileIO(open_function = BUILTIN_OPEN,
+                               listdir_function = BUILTIN_LISTDIR,
+                               path_join_function = BUILTIN_PATH_JOIN, 
+                               isdir_function = BUILTIN_ISDIR)

--- a/python/ndtiff/nd_tiff_current.py
+++ b/python/ndtiff/nd_tiff_current.py
@@ -2,16 +2,14 @@
 Library for reading NDTiff datasets
 """
 import os
-import mmap
 import numpy as np
 import sys
 import json
-import platform
 import dask.array as da
 import warnings
 import struct
 import threading
-import inspect
+from ndtiff.file_io import NDTiffFileIO, BUILTIN_FILE_IO
 
 _POSITION_AXIS = "position"
 _ROW_AXIS = "row"
@@ -38,6 +36,8 @@ class _SingleNDTiffReader:
     """
     Class corresponsing to a single multipage tiff file
     Pass the full path of the TIFF to instantiate and call close() when finished
+
+
     """
 
     # file format constants
@@ -51,15 +51,17 @@ class _SingleNDTiffReader:
 
     UNCOMPRESSED = 0
 
-    def __init__(self, tiff_path):
+    def __init__(self, tiff_path, file_io: NDTiffFileIO = BUILTIN_FILE_IO):
+        """
+        tiff_path: str
+            The path to a .tiff file to load
+        file_io: ndtiff.file_io.NDTiffFileIO
+            A container containing various methods for interacting with files.
+        """
+        self.file_io = file_io
         self.tiff_path = tiff_path
-        self.file = open(tiff_path, "rb")
-        if platform.system() == "Windows":
-            self.mmap_file = mmap.mmap(self.file.fileno(), 0, access=mmap.ACCESS_READ)
-        else:
-            self.mmap_file = mmap.mmap(self.file.fileno(), 0, prot=mmap.PROT_READ)
+        self.file = self.file_io.open(tiff_path, "rb")
         self.summary_md, self.first_ifd_offset = self._read_header()
-        self.mmap_file.close()
 
     def close(self):
         """ """
@@ -91,7 +93,6 @@ class _SingleNDTiffReader:
         first_ifd_offset = np.frombuffer(self._read(4,8), dtype=np.uint32)[0]
 
         # read custom stuff: header, summary md
-        # int.from_bytes(self.mmap_file[24:28], sys.byteorder) # should be equal to 483729 starting in version 1
         self.major_version = int.from_bytes(self._read(12, 16), sys.byteorder)
         self.minor_version = int.from_bytes(self._read(16, 20), sys.byteorder)
 
@@ -107,7 +108,6 @@ class _SingleNDTiffReader:
         """
         self.file.seek(int(start), 0)
         return self.file.read(end - start)
-        # return self.np_memmap[int(start) : int(end)].tobytes()
 
     def read_metadata(self, index):
         return json.loads(
@@ -116,7 +116,7 @@ class _SingleNDTiffReader:
             )
         )
 
-    def read_image(self, index, memmapped=False):
+    def read_image(self, index):
         if index["pixel_type"] == self.EIGHT_BIT_RGB:
             bytes_per_pixel = 3
             dtype = np.uint8
@@ -133,22 +133,12 @@ class _SingleNDTiffReader:
             raise Exception("unrecognized pixel type")
         width = index["image_width"]
         height = index["image_height"]
-
-        if memmapped:
-            np_memmap = np.memmap(self.file, dtype=np.uint8, mode="r")
-            image = np.reshape(
-                np_memmap[
-                    index["pixel_offset"] : index["pixel_offset"] + width * height * bytes_per_pixel
-                ].view(dtype),
-                [height, width, 3] if bytes_per_pixel == 3 else [height, width],
-            )
-        else:
-            image = np.reshape(
-                np.frombuffer(self._read(
-                index["pixel_offset"], index["pixel_offset"] + width * height * bytes_per_pixel)
-                    , dtype=dtype),
-                [height, width, 3] if bytes_per_pixel == 3 else [height, width],
-            )
+        image = np.reshape(
+            np.frombuffer(self._read(
+            index["pixel_offset"], index["pixel_offset"] + width * height * bytes_per_pixel)
+                , dtype=dtype),
+            [height, width, 3] if bytes_per_pixel == 3 else [height, width],
+        )
         return image
 
 class NDTiffDataset():
@@ -156,7 +146,7 @@ class NDTiffDataset():
     Class that opens a single NDTiff dataset
     """
 
-    def __init__(self, dataset_path=None, remote_storage_monitor=None, **kwargs):
+    def __init__(self, dataset_path=None, remote_storage_monitor=None, file_io: NDTiffFileIO = BUILTIN_FILE_IO, **kwargs):
         """
         Provides access to an NDTiffStorage dataset,
         either one currently being acquired or one on disk
@@ -167,7 +157,10 @@ class NDTiffDataset():
             Abosolute path of top level folder of a dataset on disk
         remote_storage_monitor : JavaObjectShadow
             Object that allows callbacks from remote NDTiffStorage. User's need not call this directly
+        file_io: ndtiff.file_io.NDTiffFileIO
+            A container containing various methods for interacting with files.
         """
+        self.file_io = file_io
         # if it is in fact a pyramid, the parent class will handle this. I think this implies that
         # resolution levels cannot be opened seperately and expected to stitch correctly when there
         # is tile overlap
@@ -194,7 +187,7 @@ class NDTiffDataset():
         self.path += "" if self.path[-1] == os.sep else os.sep
         self.index = self.read_index(self.path)
         tiff_names = [
-            os.path.join(self.path, tiff) for tiff in os.listdir(self.path) if tiff.endswith(".tif")
+            self.file_io.path_join(self.path, tiff) for tiff in self.file_io.listdir(self.path) if tiff.endswith(".tif")
         ]
         self._readers_by_filename = {}
         self.summary_metadata = {}
@@ -202,14 +195,14 @@ class NDTiffDataset():
         # Count how many files need to be opened
         num_tiffs = 0
         count = 0
-        for file in os.listdir(self.path):
+        for file in self.file_io.listdir(self.path):
             if file.endswith(".tif"):
                 num_tiffs += 1
         # populate list of readers and tree mapping indices to readers
         for tiff in tiff_names:
             print("\rOpening file {} of {}...".format(count + 1, num_tiffs), end="")
             count += 1
-            new_reader = _SingleNDTiffReader(tiff)
+            new_reader = _SingleNDTiffReader(tiff, file_io=self.file_io)
             self._readers_by_filename[tiff.split(os.sep)[-1]] = new_reader
             # Should be the same on every file so resetting them is fine
             self.major_version, self.minor_version = new_reader.major_version, new_reader.minor_version
@@ -326,7 +319,6 @@ class NDTiffDataset():
         position=None,
         row=None,
         col=None,
-        memmapped=False,
         **kwargs
     ):
         """
@@ -346,8 +338,6 @@ class NDTiffDataset():
             index of tile row for XY tiled datasets (Default value = None)
         col : int
             index of tile col for XY tiled datasets (Default value = None)
-        memmapped : bool
-             (Default value = False)
         **kwargs :
             names and integer positions of any other axes
 
@@ -360,7 +350,7 @@ class NDTiffDataset():
         with self._lock:
             axes = self._consolidate_axes(channel, z, position, time, row, col, **kwargs )
 
-            return self._do_read_image(axes, memmapped)
+            return self._do_read_image(axes)
 
     def read_metadata(
         self,
@@ -425,7 +415,7 @@ class NDTiffDataset():
             _, axes, index_entry = self._read_single_index_entry(data, self.index)
 
             if index_entry["filename"] not in self._readers_by_filename:
-                new_reader = _SingleNDTiffReader(self.path + index_entry["filename"] )
+                new_reader = _SingleNDTiffReader(self.path + index_entry["filename"], file_io=self.file_io)
                 self._readers_by_filename[index_entry["filename"]] = new_reader
                 # Should be the same on every file so resetting them is fine
                 self.major_version, self.minor_version = new_reader.major_version, new_reader.minor_version
@@ -601,7 +591,7 @@ class NDTiffDataset():
 
     def read_index(self, path):
         print("\rReading index...          ", end="")
-        with open(path + os.sep + "NDTiff.index", "rb") as index_file:
+        with self.file_io.open(path + os.sep + "NDTiff.index", "rb") as index_file:
             data = index_file.read()
         entries = {}
         position = 0
@@ -625,7 +615,6 @@ class NDTiffDataset():
     def _do_read_image(
         self,
         axes,
-        memmapped=False,
     ):
         # determine which reader contains the image
         key = frozenset(axes.items())
@@ -633,7 +622,7 @@ class NDTiffDataset():
             raise Exception("image with keys {} not present in data set".format(key))
         index = self.index[key]
         reader = self._readers_by_filename[index["filename"]]
-        return reader.read_image(index, memmapped)
+        return reader.read_image(index)
 
     def _do_read_metadata(self, axes):
         """
@@ -731,7 +720,7 @@ class NDTiffDataset():
                         if not self.has_image(**axes, **axes_to_slice, row=row, column=column):
                             blocks[-1].append(self._empty_tile)
                         else:
-                            tile = self.read_image(**axes, **axes_to_slice, row=row, column=column, memmapped=True)
+                            tile = self.read_image(**axes, **axes_to_slice, row=row, column=column)
                             # remove half of the overlap around each tile so that that image stitches correctly
                             # only need this for full resoution because downsampled ones already have the edges removed
                             if np.any(self.overlap[0] > 0) and self._full_resolution:
@@ -779,7 +768,7 @@ class NDTiffDataset():
 class NDTiffPyramidDataset():
     """Class that opens a single NDTiffStorage multi-resolution pyramid dataset"""
 
-    def __init__(self, dataset_path=None, remote_storage_monitor=None):
+    def __init__(self, dataset_path=None, remote_storage_monitor=None, file_io: NDTiffFileIO = BUILTIN_FILE_IO):
         """
         Provides access to a NDTiffStorage pyramid dataset,
         either one currently being acquired or one on disk
@@ -790,7 +779,10 @@ class NDTiffPyramidDataset():
             Abosolute path of top level folder of a dataset on disk
         remote_storage_monitor : JavaObjectShadow
             Object that allows callbacks from remote NDTiffStorage. Users need not call this directly
+        file_io: ndtiff.file_io.NDTiffFileIO
+            A container containing various methods for interacting with files.
         """
+        self.file_io = file_io
         self._lock = threading.RLock()
         if remote_storage_monitor is not None:
             self._remote_storage_monitor = None # It belongs to the full resolution subclass
@@ -820,7 +812,7 @@ class NDTiffPyramidDataset():
         self.path = dataset_path
         self.path += "" if self.path[-1] == os.sep else os.sep
         res_dirs = [
-            dI for dI in os.listdir(dataset_path) if os.path.isdir(os.path.join(dataset_path, dI))
+            dI for dI in self.file_io.listdir(dataset_path) if self.file_io.isdir(self.file_io.path_join(dataset_path, dI))
         ]
         # map from downsample factor to dataset
         with self._lock:
@@ -832,8 +824,8 @@ class NDTiffPyramidDataset():
             )
 
         for res_dir in res_dirs:
-            res_dir_path = os.path.join(dataset_path, res_dir)
-            res_level = NDTiffDataset(dataset_path=res_dir_path)
+            res_dir_path = self.file_io.path_join(dataset_path, res_dir)
+            res_level = NDTiffDataset(dataset_path=res_dir_path, file_io=self.file_io)
             if res_dir == "Full resolution":
                 with self._lock:
                     self.res_levels[0] = res_level
@@ -1016,7 +1008,6 @@ class NDTiffPyramidDataset():
         col=None,
         channel_name=None,
         resolution_level=0,
-        memmapped=False,
         **kwargs
     ):
         """
@@ -1041,8 +1032,6 @@ class NDTiffPyramidDataset():
         resolution_level :
             0 is full resolution, otherwise represents downampling of pixels
             at 2 ** (resolution_level) (Default value = 0)
-        memmapped : bool
-             (Default value = False)
         **kwargs :
             names and integer positions of any other axes
 
@@ -1060,7 +1049,6 @@ class NDTiffPyramidDataset():
                     row=row,
                     col=col,
                     channel_name=channel_name,
-                    memmapped=memmapped,
                     **kwargs)
 
     def read_metadata(

--- a/python/ndtiff/nd_tiff_v2.py
+++ b/python/ndtiff/nd_tiff_v2.py
@@ -2,16 +2,14 @@
 Library for reading multiresolution micro-magellan
 """
 import os
-import mmap
 import numpy as np
 import sys
 import json
-import platform
 import dask.array as da
 import warnings
 import struct
 import threading
-
+from ndtiff.file_io import NDTiffFileIO, BUILTIN_FILE_IO
 
 class _MultipageTiffReader:
     """
@@ -26,15 +24,17 @@ class _MultipageTiffReader:
     EIGHT_BIT_RGB = 2
     UNCOMPRESSED = 0
 
-    def __init__(self, tiff_path):
+    def __init__(self, tiff_path, file_io: NDTiffFileIO = BUILTIN_FILE_IO):
+        """
+        tiff_path: str
+            The path to a .tiff file to load
+        file_io: ndtiff.file_io.NDTiffFileIO
+            A container containing various methods for interacting with files.
+        """
+        self.file_io = file_io
         self.tiff_path = tiff_path
-        self.file = open(tiff_path, "rb")
-        if platform.system() == "Windows":
-            self.mmap_file = mmap.mmap(self.file.fileno(), 0, access=mmap.ACCESS_READ)
-        else:
-            self.mmap_file = mmap.mmap(self.file.fileno(), 0, prot=mmap.PROT_READ)
+        self.file = self.file_io.open(tiff_path, "rb")
         self.summary_md, self.first_ifd_offset = self._read_header()
-        self.mmap_file.close()
 
     def close(self):
         """ """
@@ -66,7 +66,6 @@ class _MultipageTiffReader:
         first_ifd_offset = np.frombuffer(self._read(4,8), dtype=np.uint32)[0]
 
         # read custom stuff: header, summary md
-        # int.from_bytes(self.mmap_file[24:28], sys.byteorder) # should be equal to 483729 starting in version 1
         self._major_version = int.from_bytes(self._read(12,16), sys.byteorder)
 
         summary_md_header, summary_md_length = np.frombuffer(self._read(16,24), dtype=np.uint32)
@@ -87,7 +86,6 @@ class _MultipageTiffReader:
         """
         self.file.seek(int(start), 0)
         return self.file.read(end - start)
-        # return self.np_memmap[int(start) : int(end)].tobytes()
 
     def read_metadata(self, index):
         return json.loads(
@@ -96,7 +94,7 @@ class _MultipageTiffReader:
             )
         )
 
-    def read_image(self, index, memmapped=False):
+    def read_image(self, index):
         if index["pixel_type"] == self.EIGHT_BIT_RGB:
             bytes_per_pixel = 3
             dtype = np.uint8
@@ -111,26 +109,17 @@ class _MultipageTiffReader:
         width = index["image_width"]
         height = index["image_height"]
 
-        if memmapped:
-            np_memmap = np.memmap(self.file, dtype=np.uint8, mode="r")
-            image = np.reshape(
-                np_memmap[
-                    index["pixel_offset"] : index["pixel_offset"] + width * height * bytes_per_pixel
-                ].view(dtype),
-                [height, width, 3] if bytes_per_pixel == 3 else [height, width],
-            )
-        else:
-            image = np.reshape(
-                np.frombuffer(self._read(
-                index["pixel_offset"], index["pixel_offset"] + width * height * bytes_per_pixel)
-                    , dtype=dtype),
-                [height, width, 3] if bytes_per_pixel == 3 else [height, width],
-            )
+        image = np.reshape(
+            np.frombuffer(self._read(
+            index["pixel_offset"], index["pixel_offset"] + width * height * bytes_per_pixel)
+                , dtype=dtype),
+            [height, width, 3] if bytes_per_pixel == 3 else [height, width],
+        )
         return image
 
 
 class _ResolutionLevel:
-    def __init__(self, path=None, count=None, max_count=None, remote=False, summary_metadata=False):
+    def __init__(self, path=None, count=None, max_count=None, remote=False, summary_metadata=False, file_io: NDTiffFileIO = BUILTIN_FILE_IO):
         """
         Open all tiff files in directory, keep them in a list, and a tree based on image indices
 
@@ -141,6 +130,7 @@ class _ResolutionLevel:
         max_count : int
 
         """
+        self.file_io = file_io
         self.path_root = path + ("" if path[-1] == os.sep else os.sep)
         if remote:
             self.summary_metadata = summary_metadata
@@ -149,14 +139,14 @@ class _ResolutionLevel:
         else:
             self.index = self.read_index(path)
             tiff_names = [
-                os.path.join(path, tiff) for tiff in os.listdir(path) if tiff.endswith(".tif")
+                self.file_io.path_join(path, tiff) for tiff in self.file_io.listdir(path) if tiff.endswith(".tif")
             ]
             self._readers_by_filename = {}
             # populate list of readers and tree mapping indices to readers
             for tiff in tiff_names:
                 print("\rOpening file {} of {}...".format(count + 1, max_count), end="")
                 count += 1
-                self._readers_by_filename[tiff.split(os.sep)[-1]] = _MultipageTiffReader(tiff)
+                self._readers_by_filename[tiff.split(os.sep)[-1]] = _MultipageTiffReader(tiff, file_io=self.file_io)
             self.summary_metadata = list(self._readers_by_filename.values())[0].summary_md
 
     def has_image(self, axes):
@@ -172,7 +162,7 @@ class _ResolutionLevel:
 
         if index_entry["filename"] not in self._readers_by_filename:
             self._readers_by_filename[index_entry["filename"]] = _MultipageTiffReader(
-                self.path_root + index_entry["filename"]
+                self.path_root + index_entry["filename"], file_io=self.file_io
             )
         return axes, index_entry
 
@@ -208,7 +198,7 @@ class _ResolutionLevel:
 
     def read_index(self, path):
         print("\rReading index...          ", end="")
-        with open(path + os.sep + "NDTiff.index", "rb") as index_file:
+        with self.file_io.open(path + os.sep + "NDTiff.index", "rb") as index_file:
             data = index_file.read()
         entries = {}
         position = 0
@@ -232,15 +222,12 @@ class _ResolutionLevel:
     def read_image(
         self,
         axes,
-        memmapped=False,
     ):
         """
 
         Parameters
         ----------
         axes : dict
-        memmapped : bool
-             (Default value = False)
 
         Returns
         -------
@@ -252,7 +239,7 @@ class _ResolutionLevel:
             raise Exception("image with keys {} not present in data set".format(key))
         index = self.index[key]
         reader = self._readers_by_filename[index["filename"]]
-        return reader.read_image(index, memmapped)
+        return reader.read_image(index)
 
     def read_metadata(self, axes):
         """
@@ -290,7 +277,7 @@ class NDTiff_v2_0():
     _TIME_AXIS = "time"
     _CHANNEL_AXIS = "channel"
 
-    def __init__(self, dataset_path=None, full_res_only=True, remote_storage_monitor=None):
+    def __init__(self, dataset_path=None, full_res_only=True, remote_storage_monitor=None, file_io: NDTiffFileIO = BUILTIN_FILE_IO):
         """
         Creat a Object providing access to and NDTiffStorage dataset, either one currently being acquired or one on disk
 
@@ -302,7 +289,10 @@ class NDTiff_v2_0():
             One open the full resolution data, if it is multi-res
         remote_storage_monitor : JavaObjectShadow
             Object that allows callbacks from remote NDTiffStorage
+        file_io: ndtiff.file_io.NDTiffFileIO
+            A container containing various methods for interacting with files.
         """
+        self.file_io = file_io
         self._tile_width = None
         self._tile_height = None
         self._lock = threading.Lock()
@@ -325,7 +315,8 @@ class NDTiff_v2_0():
             with self._lock:
                 self.res_levels = {
                     0: _ResolutionLevel(
-                        remote=True, summary_metadata=self.summary_metadata, path=full_res_path
+                        remote=True, summary_metadata=self.summary_metadata, path=full_res_path,
+                        file_io=self.file_io
                     )
                 }
             self.axes = {}
@@ -335,7 +326,7 @@ class NDTiff_v2_0():
 
         self.path = dataset_path
         res_dirs = [
-            dI for dI in os.listdir(dataset_path) if os.path.isdir(os.path.join(dataset_path, dI))
+            dI for dI in self.file_io.listdir(dataset_path) if self.file_io.isdir(self.file_io.path_join(dataset_path, dI))
         ]
         # map from downsample factor to datset
         with self._lock:
@@ -347,14 +338,14 @@ class NDTiff_v2_0():
         num_tiffs = 0
         count = 0
         for res_dir in res_dirs:
-            for file in os.listdir(os.path.join(dataset_path, res_dir)):
+            for file in self.file_io.listdir(self.file_io.path_join(dataset_path, res_dir)):
                 if file.endswith(".tif"):
                     num_tiffs += 1
         for res_dir in res_dirs:
             if full_res_only and res_dir != "Full resolution":
                 continue
-            res_dir_path = os.path.join(dataset_path, res_dir)
-            res_level = _ResolutionLevel(res_dir_path, count, num_tiffs)
+            res_dir_path = self.file_io.path_join(dataset_path, res_dir)
+            res_level = _ResolutionLevel(res_dir_path, count, num_tiffs, file_io=self.file_io)
             if res_dir == "Full resolution":
                 with self._lock:
                     self.res_levels[0] = res_level
@@ -531,7 +522,7 @@ class NDTiff_v2_0():
                         if not self.has_image(**axes, **axes_to_slice, row=row, column=column):
                             blocks[-1].append(self._empty_tile)
                         else:
-                            tile = self.read_image(**axes, **axes_to_slice, row=row, column=column, memmapped=True)
+                            tile = self.read_image(**axes, **axes_to_slice, row=row, column=column)
                             if self.half_overlap[0] != 0:
                                 tile = tile[
                                     self.half_overlap[0] : -self.half_overlap[0],
@@ -628,7 +619,6 @@ class NDTiff_v2_0():
         col=None,
         channel_name=None,
         resolution_level=0,
-        memmapped=False,
         **kwargs
     ):
         """
@@ -653,8 +643,6 @@ class NDTiff_v2_0():
         resolution_level :
             0 is full resolution, otherwise represents downampling of pixels
             at 2 ** (resolution_level) (Default value = 0)
-        memmapped : bool
-             (Default value = False)
         **kwargs :
             names and integer positions of any other axes
 
@@ -670,7 +658,7 @@ class NDTiff_v2_0():
             )
 
             res_level = self.res_levels[resolution_level]
-            return res_level.read_image(axes, memmapped)
+            return res_level.read_image(axes)
 
     def read_metadata(
         self,

--- a/python/ndtiff/test/conftest.py
+++ b/python/ndtiff/test/conftest.py
@@ -1,0 +1,6 @@
+import os
+import pytest
+
+@pytest.fixture
+def test_data_path() -> str:
+    return os.path.join(os.path.dirname(__file__), "..", "..", "..", "test_data")

--- a/python/ndtiff/test/data_loading_test.py
+++ b/python/ndtiff/test/data_loading_test.py
@@ -2,21 +2,20 @@ import numpy as np
 from ndtiff import Dataset
 import os
 
-test_data_path = os.path.join(os.getcwd(), 'test_data')
 
-def test_v2_data():
+def test_v2_data(test_data_path):
     data_path = os.path.join(test_data_path, "v2", "ndtiffv2.0_test")
     dataset = Dataset(data_path)
     assert(np.mean(dataset.as_array()) > 0)
 
-def test_v3_data():
+def test_v3_data(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', 'ndtiffv3.0_test')
     dataset = Dataset(data_path)
     assert(np.mean(dataset.as_array()) > 0)
     for channel_name, correct_channel_name in zip(dataset.get_channel_names(), ['DAPI', 'FITC']):
         assert(channel_name == correct_channel_name)
 
-def test_v2_stitched_data():
+def test_v2_stitched_data(test_data_path):
     data_path = os.path.join(test_data_path, "v2", "ndtiffv2.0_stitched_test")
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array(stitched=True))
@@ -25,7 +24,7 @@ def test_v2_stitched_data():
     assert(stitched[..., 0, -1] == 0)
     assert(stitched[..., -1, 0] == 0)
 
-def test_v3_stitched_data():
+def test_v3_stitched_data(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', 'ndtiffv3.0_stitched_test')
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array(stitched=True, res_level=0))
@@ -34,34 +33,34 @@ def test_v3_stitched_data():
     assert(stitched[..., 0, -1] == 0)
     assert(stitched[..., -1, 0] == 0)
 
-def test_v3_magellan_explore():
+def test_v3_magellan_explore(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', 'Magellan_expolore_multi_channel')
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array(stitched=True, res_level=0))
     
-def test_v3_magellan_explore_negative_and_overwritten():
+def test_v3_magellan_explore_negative_and_overwritten(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', 'Magellan_expolore_negative_indices_and_overwritten')
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array(stitched=True, res_level=0))
 
-def test_v3_non_ctzp_axes():
+def test_v3_non_ctzp_axes(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', 'Nonstandard_axis_names')
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array())
 
-def test_v3_mm_mda():
+def test_v3_mm_mda(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', 'mm_mda_tcz_15')
     dataset = Dataset(data_path)
     stitched = np.array(dataset.as_array())
 
-def test_v3_2_multichannel():
+def test_v3_2_multichannel(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', 'ndtiff3.2_multichannel')
     dataset = Dataset(data_path)
     assert(np.mean(dataset.read_image(channel='DAPI', time=0, z=1)) > 0)
     for channel_name, correct_channel_name in zip(dataset.get_channel_names(), ['DAPI', 'FITC']):
         assert(channel_name == correct_channel_name)
 
-def test_v3_2_multichannel_axis_sorting():
+def test_v3_2_multichannel_axis_sorting(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', 'ndtiff3.2_multichannel')
     dataset = Dataset(data_path)
     num_timepoints = len(dataset.axes['time'])
@@ -70,17 +69,17 @@ def test_v3_2_multichannel_axis_sorting():
     data = dataset.as_array(axes=None)
     assert data.shape[:-2] == (num_timepoints, num_channels, num_slices)
 
-def test_v3_2_monochrome():
+def test_v3_2_monochrome(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', 'ndtiff3.2_monochrome')
     dataset = Dataset(data_path)
     assert (np.mean(dataset.read_image(time=0, z=1)) > 0)
 
-def test_v3_2_magellan_rgb_explore():
+def test_v3_2_magellan_rgb_explore(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', 'ndtiff3.2_magellan_explore_rgb')
     dataset = Dataset(data_path)
     assert(np.sum(np.array(dataset.as_array(stitched=True)[0])) > 0)
 
-def test_v3_2_12bit_pycromanager_data():
+def test_v3_2_12bit_pycromanager_data(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', '12_bit_pycromanager_mda')
     dataset = Dataset(data_path)
     assert(dataset.read_image(time=0, channel='DAPI').dtype == np.uint16)

--- a/python/ndtiff/test/test_custom_io.py
+++ b/python/ndtiff/test/test_custom_io.py
@@ -1,0 +1,57 @@
+import numpy as np
+from ndtiff import Dataset, file_io
+import os
+import pytest
+from typing import List
+
+class BadOpenError(Exception):
+    pass
+
+class BadListdirError(Exception):
+    pass
+
+class BadPathJoinError(Exception):
+    pass
+
+class BadIsDirError(Exception):
+    pass
+
+def bad_open_function(*args, **kwargs):
+    raise BadOpenError
+
+def bad_listdir(*args, **kwargs):
+    raise BadListdirError
+
+def bad_path_join(*args, **kwargs):
+    raise BadPathJoinError
+
+def bad_isdir(*args, **kwargs):
+    raise BadIsDirError
+
+def test_bad_open(test_data_path):
+    data_path_list: List[str] = [
+        os.path.join(test_data_path, "v2", "ndtiffv2.0_test"),
+        os.path.join(test_data_path, 'v3', 'ndtiffv3.0_test'),
+        os.path.join(test_data_path, "v2", "ndtiffv2.0_stitched_test"),
+        os.path.join(test_data_path, 'v3', 'ndtiffv3.0_stitched_test'),
+        os.path.join(test_data_path, 'v3', 'Magellan_expolore_multi_channel'),
+        os.path.join(test_data_path, 'v3', 'Magellan_expolore_negative_indices_and_overwritten'),
+        os.path.join(test_data_path, 'v3', 'Nonstandard_axis_names'),
+        os.path.join(test_data_path, 'v3', 'mm_mda_tcz_15'),
+        os.path.join(test_data_path, 'v3', 'ndtiff3.2_multichannel'),
+        os.path.join(test_data_path, 'v3', 'ndtiff3.2_monochrome'),
+        os.path.join(test_data_path, 'v3', 'ndtiff3.2_magellan_explore_rgb'),
+        os.path.join(test_data_path, 'v3', '12_bit_pycromanager_mda'),
+    ]
+    
+    # Ensure each dataset loads using the custom open command by raising an exception within it
+    # and checking that this exception occured
+    for data_path in data_path_list:
+        with pytest.raises(BadOpenError):
+            Dataset(data_path, file_io=file_io.NDTiffFileIO(open_function=bad_open_function))
+        with pytest.raises(BadListdirError):
+            Dataset(data_path, file_io=file_io.NDTiffFileIO(listdir_function=bad_listdir))
+        with pytest.raises(BadPathJoinError):
+            Dataset(data_path, file_io=file_io.NDTiffFileIO(listdir_function=bad_path_join))
+        with pytest.raises(BadIsDirError):
+            Dataset(data_path, file_io=file_io.NDTiffFileIO(listdir_function=bad_isdir))


### PR DESCRIPTION
# Summary
Enables the use of custom file io functions instead of builtin methods (such as `open`). This is useful in situations where a user loads a dataset from a non-physical resource such as cloud storage. This is implemented using a new `ndtiff.file_io.NDTiffFileIO` class which wraps `open`, `os.listdir`, `os.path.join`, and `os.path.isdir`, enabling the replacement of one or all of these functions with custom methods. For example:

```
from _your_custom_storage_module_ import storage
import ndtiff

file_io = ndtiff.file_io.NDTiffFileIO(open_function=storage.open,
                                      listdir_function=storage.listdir,
                                      path_join_function=storage.pathjoin, 
                                      isdir_function=storage.isdir)

dset = ndtiff.Dataset("s3://bucket_name/path/to/your/dataset", file_io=file_io)
```

By default, the builtin `open` and `os.path` methods are used.

## Changes
- Added `file_io.py`, containing a container `NDTiffFileIO` which allows the user to add custom io commands
- Removed mmap commands in all locations, as they are unneeded according to @henrypinkard. I did have to rework `read_image` in v1 quite a bit, so that's worth reviewing closely.
- Replaced all `open`, `os.path.join`, `os.listdir`, and `os.path.isdir` calls with `file_io` calls
- Added `conftest.py` and added a pytest fixture for test data path
- Added `test_custom_io.py` to test this new interface

## Tests
```
~/repos/NDTiffStorage/python/ndtiff remove_mmap_and_add_support_for_custom_open_function
pyxscope ❯ pytest
============================================ test session starts ============================================
platform darwin -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/zack/repos/NDTiffStorage/python, configfile: pyproject.toml
plugins: cov-2.12.1, Flask-Dance-6.1.1, anyio-3.6.2
collected 14 items                                                                                          

test/data_loading_test.py .............                                                               [ 92%]
test/test_custom_io.py .                                                                              [100%]

============================================ 14 passed in 0.57s =============================================
```