### PR TITLE
Fix ResourceWarning: unclosed file <_io.BufferedReader name=...>

### DIFF
--- a/python/ndtiff/_superclass.py
+++ b/python/ndtiff/_superclass.py
@@ -43,6 +43,7 @@ class Dataset:
         file = file_io.open(fullres_path + a_tiff_file, "rb")
         file.seek(12)
         major_version = np.frombuffer(file.read(4), dtype=np.uint32)[0]
+        file.close()
         if major_version == 3:
             obj = NDTiffPyramidDataset.__new__(NDTiffPyramidDataset)
             obj.__init__(dataset_path=dataset_path, file_io=file_io)


### PR DESCRIPTION
```python
# resourcewarning.py
import tracemalloc
import ndtiff

tracemalloc.start()
ndt = ndtiff.Dataset('ndtiffv2.0_test')
ndt.close()
```

`$ python -X dev resourcewarning.py`
```
Dataset opened
resourcewarning.py:6: ResourceWarning: unclosed file <_io.BufferedReader name='ndtiffv2.0_test\\Full resolution\\ndtiffv2.0_test_NDTiffStack.tif'>
  ndt = ndtiff.Dataset('ndtiffv2.0_test')
Object allocated at (most recent call last):
  File "X:\Python310\lib\site-packages\ndtiff\_superclass.py", lineno 43
    file = file_io.open(fullres_path + a_tiff_file, "rb")
```