### PR TITLE
Implement axis sorting on v2 datasets

### DIFF
--- a/python/ndtiff/_version.py
+++ b/python/ndtiff/_version.py
@@ -1,2 +1,2 @@
-version_info = (2, 0, 0)
+version_info = (2, 1, 0)
 __version__ = ".".join(map(str, version_info))

--- a/python/ndtiff/test/data_loading_test.py
+++ b/python/ndtiff/test/data_loading_test.py
@@ -8,6 +8,14 @@ def test_v2_data(test_data_path):
     dataset = Dataset(data_path)
     assert(np.mean(dataset.as_array()) > 0)
 
+def test_v2_data_axis_sorting(test_data_path):
+    data_path = os.path.join(test_data_path, "v2", "ndtiffv2.0_test")
+    dataset = Dataset(data_path)
+    num_timepoints = len(dataset.axes['time'])
+    num_channels = len(dataset.axes['channel'])
+    data = dataset.as_array(axes=None)
+    assert data.shape[:-2] == (num_timepoints, num_channels)
+
 def test_v3_data(test_data_path):
     data_path = os.path.join(test_data_path, 'v3', 'ndtiffv3.0_test')
     dataset = Dataset(data_path)


### PR DESCRIPTION
Implement axis sorting in PTCZ order for calls to `as_array(axis=None)` in v2 datasets similar to #75 