### PR TITLE
Modifications to enable O(log N) cost add_axis_index

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,3 @@
 numpy
+sortedcontainer
 dask[array]>=2022.2.0


### PR DESCRIPTION
I have converted the representation of axis indexes to go from list to the SortedSet representation. This changes the time complexity of updates from O(N^2) to O(log N).  This makes it possible to perform significantly larger acquisition sequences than is currently possible.