### PR TITLE
setup.py now uses requirements.txt instead of hard coding

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -11,6 +11,9 @@ with open(path, encoding="utf8") as f:
     exec(f.read(), {}, version_ns)
 version = version_ns["__version__"]
 
+with open("requirements.txt") as f:
+    requirements = f.read().splitlines()
+
 setuptools.setup(
     name="ndtiff",
     version=version,
@@ -21,10 +24,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/micro-manager/NDTiffStorage",
     packages=setuptools.find_packages(),
-    install_requires=[
-        "numpy",
-        "dask[array]>=2022.2.0",
-    ],
+    install_requires=requirements,
     python_requires=">=3.6",
     extras_require={
         "test": [


### PR DESCRIPTION
I found that `sortedcontainers` wasn't being installed on my local clone, so I modified `setup.py` to use `requirements.txt`